### PR TITLE
Update in Manticore Search cheat sheet

### DIFF
--- a/src/ManticoreSearch/README.md
+++ b/src/ManticoreSearch/README.md
@@ -2,4 +2,4 @@
 - https://manticoresearch.com/
 - https://github.com/manticoresoftware/manticoresearch/
 - https://github.com/manticoresoftware/manticoresearch-php
-- https://github.com/manticoresoftware/go-sdk
+- https://github.com/manticoresoftware/manticoresearch-go


### PR DESCRIPTION
Go SDK has been deprecated. It's recommended to use https://github.com/manticoresoftware/manticoresearch-go instead.